### PR TITLE
Fix for Xenial systemd

### DIFF
--- a/libvirt/files/libvirt-bin
+++ b/libvirt/files/libvirt-bin
@@ -5,7 +5,14 @@
 start_libvirtd="yes"
 
 # options passed to libvirtd, add "-l" to listen on tcp
+{%- if grains.get('init', None) != 'systemd' %}
+
 libvirtd_opts="-d -l"
+{%- else %}
+# Don't use "-d" option with systemd
+
+libvirt_opts="-l"
+{%- endif %}
 
 # pass in location of kerberos keytab
 #export KRB5_KTNAME=/etc/libvirt/libvirt.keytab

--- a/libvirt/server/service.sls
+++ b/libvirt/server/service.sls
@@ -43,10 +43,22 @@ libvirt_sysconfig:
 /etc/default/libvirt-bin:
   file.managed:
   - source: salt://libvirt/files/libvirt-bin
+  - template: jinja
   - require:
     - pkg: libvirt_packages
   - watch_in:
     - service: libvirt_service
+{%- if grains.get('init', None) == 'systemd' %}
+
+libvirt_restart_systemd:
+  module.wait:
+  - name: service.systemctl_reload
+  - watch:
+    - file: /etc/default/libvirt-bin
+  - require_in:
+    - service: libvirt_service
+
+{%- endif %}
 
 {%- endif %}
 


### PR DESCRIPTION
Xenial systemd unit files are not compatible with libvirt -d option enforced in /etc/default/libvirt-bin file