### PR TITLE
Fixed problem with os_family based config file

### DIFF
--- a/libvirt/files/libvirtd.conf
+++ b/libvirt/files/libvirtd.conf
@@ -21,6 +21,7 @@
 #
 # This is enabled by default, uncomment this to disable it
 #listen_tls = 0
+listen_tls = {{ server.config.listen_tls|default(1, true) }}
 
 # Listen for unencrypted TCP connections on the public TCP/IP port.
 # NB, must pass the --listen flag to the libvirtd process for this to
@@ -32,10 +33,8 @@
 #
 # This is disabled by default, uncomment this to enable it.
 #listen_tcp = 1
+listen_tcp = {{ server.config.listen_tcp|default(0, true)}}
 
-listen_tls = 0
-listen_tcp = 1
-auth_tcp="none"
 
 
 # Override the port for accepting secure TLS connections
@@ -148,6 +147,7 @@ auth_unix_rw = "none"
 # use, always enable SASL and use the GSSAPI or DIGEST-MD5
 # mechanism in /etc/sasl2/libvirt.conf
 #auth_tcp = "sasl"
+auth_tcp="{{ server.config.auth_tcp|default('sasl', true) }}"
 
 # Change the authentication scheme for TLS sockets.
 #

--- a/libvirt/map.jinja
+++ b/libvirt/map.jinja
@@ -3,14 +3,21 @@
         'pkgs': ['libvirt-bin','pm-utils','libvirt0','python-libvirt'],
         'kvm_pkgs': ['qemu-kvm','qemu-utils'],
         'service': 'libvirt-bin',
-        'config': '/etc/libvirt/libvirtd.conf',
-        'config_sys': '/etc/default/libvirt-bin'
+        'config': {
+            'file': '/etc/libvirt/libvirtd.conf',
+            'auth_tcp': 'none',
+            'listen_tls': 0,
+            'listen_tcp': 1
+        },
+        'config_sys': '/etc/default/libvirt-bin',
     },
     'RedHat': {
         'pkgs': ['libvirt'],
         'kvm_pkgs': ['qemu-kvm'],
         'service': 'libvirtd',
-        'config': '/etc/libvirt/libvirtd.conf',
+        'config': {
+            'file': '/etc/libvirt/libvirtd.conf'
+        },
         'config_sys': '/etc/sysconfig/libvirtd'
     },
 }, merge=salt['pillar.get']('libvirt:server')) %}

--- a/libvirt/server/service.sls
+++ b/libvirt/server/service.sls
@@ -19,8 +19,8 @@ libvirt_kvm_packages:
 
 libvirt_config:
   file.managed:
-  - name: {{ server.config }}
-  - source: salt://libvirt/files/libvirtd.conf.{{ grains.os_family }}
+  - name: {{ server.config.file }}
+  - source: salt://libvirt/files/libvirtd.conf
   - template: jinja
   - require:
     - pkg: libvirt_packages


### PR DESCRIPTION
There was just a configuration file template for Debian available.
So it did not work on !Debian systems.

Took the template and made it configurable by map.jinja for Debian
and used defaults for others.

But shouldn't these be configured in the pillars?